### PR TITLE
Improve Stream Updating & Fix Memory Leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ open basic.html
 ### Streaming from MFEM
 
 The _examples/websockets.html_ webpage can be used for inline visualization from MFEM with the
-`m2w.py` script. `m2w.py` forwards MFEM visualization messages to the webpage using websockets.
+`glvis-browser-server` script. `glvis-browser-server` forwards MFEM visualization messages to the webpage using websockets.
 
 Example usages:
 
-1. `cd glvis-js && ./m2w.py`
+1. `cd glvis-js && ./glvis-browser-server`
 
    - requires Python 3.7+
    - assumes default MFEM port of `19916`
@@ -39,7 +39,7 @@ Example usages:
 
 3. `cd mfem/examples && ./ex1` or `cd mfem/examples && ./ex9 -vs 20`
 
-4. `ctrl-c` to stop `m2w.py`
+4. `ctrl-c` to stop `glvis-browser-server`
 
 ## Building _glvis.js_
 

--- a/examples/websockets.html
+++ b/examples/websockets.html
@@ -455,7 +455,7 @@
         document.getElementById(id).style.width = "0";
       }
 
-      // pause bottom for streams
+      // pause button for streams
       var stream_paused = false;
       var pause_button = document.getElementById("pause-btn");
       function setToggleStreamPauseText() {

--- a/examples/websockets.html
+++ b/examples/websockets.html
@@ -479,6 +479,11 @@
           await new Promise((r) => setTimeout(r, 500));
         }
         await glv.updateStream(msg);
+        if (msg.endsWith("pause\n")) {
+          console.log("pausing");
+          stream_paused = true;
+          setToggleStreamPauseText();
+        }
         await new Promise((r) => setTimeout(r, 50));
       });
 

--- a/examples/websockets.html
+++ b/examples/websockets.html
@@ -79,6 +79,10 @@
             >Connect</label
           >
         </div>
+
+        <div>
+          <label class="menu-button" type="button" id="pause-btn"></label>
+        </div>
       </div>
 
       <!-- delay slider-->
@@ -451,10 +455,30 @@
         document.getElementById(id).style.width = "0";
       }
 
+      // pause bottom for streams
+      var stream_paused = false;
+      var pause_button = document.getElementById("pause-btn");
+      function setToggleStreamPauseText() {
+        if (stream_paused) {
+          pause_button.innerHTML = "Resume";
+        } else {
+          pause_button.innerHTML = "Pause";
+        }
+      }
+
+      setToggleStreamPauseText();
+      pause_button.onclick = function () {
+        stream_paused = !stream_paused;
+        setToggleStreamPauseText();
+      };
+
       // websocket setup
       var ws = undefined;
       var que = async.queue(async function (msg) {
-        glv.displayStream(msg);
+        while (stream_paused) {
+          await new Promise((r) => setTimeout(r, 500));
+        }
+        await glv.updateStream(msg);
         await new Promise((r) => setTimeout(r, 50));
       });
 
@@ -481,8 +505,7 @@
           console.log("disconnected");
           btn.innerHTML = "Connect";
         });
-        ws.addEventListener("message", function (event) {
-          console.log(`got message from ${event.origin}`);
+        ws.addEventListener("message", async function (event) {
           que.push(event.data);
         });
       }

--- a/glvis-browser-server
+++ b/glvis-browser-server
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
 #
-# m2w.py is an mfem to websocket forwarder to make it easier to use glvis-js as a viewer for inline
-# mfem visualization. m2w.py must be run before opening the web-client and mfem.
+# glvis-browser-server is an mfem to websocket forwarder to make it easier to use glvis-js as a
+# viewer for inline mfem visualization. m2w.py must be run before opening the web-client and mfem.
 #
-# m2w.py requires the websockets Python library (pip install websockets) and have been tested with
-# Python 3.7. Earlier versions may work.
+# glvis-browser-server requires the websockets Python library (pip install websockets) and have
+# been tested with Python 3.7. Earlier versions may work.
 #
 
 import argparse
@@ -13,7 +13,7 @@ import asyncio
 import logging
 import websockets
 
-logger = logging.getLogger('websockets.server')
+logger = logging.getLogger("websockets.server")
 logger.setLevel(logging.ERROR)
 logger.addHandler(logging.StreamHandler())
 
@@ -31,8 +31,10 @@ async def ws_handler(queue, websocket, path):
         print(f"sending {msg[0:min(len(msg), 20)]}...")
         try:
             await websocket.send(msg)
-        except (websockets.exceptions.ConnectionClosedOK,
-                websockets.exceptions.ConnectionClosedError) as e:
+        except (
+            websockets.exceptions.ConnectionClosedOK,
+            websockets.exceptions.ConnectionClosedError,
+        ):
             # if there is only one message we can requeue it, otherwise
             # drop it
             if queue.empty():
@@ -42,13 +44,19 @@ async def ws_handler(queue, websocket, path):
 
 
 async def mfem_handler(queue, reader, writer, timeout=1, block_size=1024):
-    print("mfem client connected")
+    peername = writer.get_extra_info("peername")
+    if peername is not None:
+        client, port = peername
+    else:
+        client, port = "unknown", 0
+    print(f"new mfem client: {client}@{port}")
     msg = b""
 
     while True:
         try:
             block = await asyncio.wait_for(reader.read(block_size), timeout)
-            if not block: break
+            if not block:
+                break
             idx = block.rfind(b"solution")
             if (idx != -1 and msg) or idx > 0:
                 msg += block[:idx]
@@ -61,8 +69,9 @@ async def mfem_handler(queue, reader, writer, timeout=1, block_size=1024):
                 queue.put_nowait(msg.decode())
                 msg = b""
 
-    if msg: queue.put_nowait(msg.decode())
-    print("mfem client disconnected")
+    if msg:
+        queue.put_nowait(msg.decode())
+    print(f"mfem client disconnected: {client}@{port}")
 
 
 async def create_mfem_server(queue):
@@ -70,7 +79,10 @@ async def create_mfem_server(queue):
 
     async def handler_wrap(reader, writer):
         await mfem_handler(queue, reader, writer)
-    server = await asyncio.create_task(asyncio.start_server(handler_wrap, host="localhost", port=args.port))
+
+    server = await asyncio.create_task(
+        asyncio.start_server(handler_wrap, host="localhost", port=args.port)
+    )
     await server.serve_forever()
     print("mfem server: complete")
 
@@ -82,9 +94,10 @@ async def main():
         await ws_handler(queue, websocket, path)
 
     ws_server = websockets.serve(ws_handler_wrap, "localhost", args.ws_port)
-    t2 = asyncio.create_task(create_mfem_server(queue))
+    mfem_server = asyncio.create_task(create_mfem_server(queue))
 
     await ws_server
-    await t2
+    await mfem_server
+
 
 asyncio.run(main())

--- a/glvis-browser-server
+++ b/glvis-browser-server
@@ -1,12 +1,25 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
+# Copyright (c) 2010-2020, Lawrence Livermore National Security, LLC. Produced
+# at the Lawrence Livermore National Laboratory. All Rights reserved. See files
+# LICENSE and NOTICE for details. LLNL-CODE-443271.
 #
-# glvis-browser-server is an mfem to websocket forwarder to make it easier to use glvis-js as a
-# viewer for inline mfem visualization. m2w.py must be run before opening the web-client and mfem.
+# This file is part of the GLVis visualization tool and library. For more
+# information and source code availability see https://glvis.org.
 #
-# glvis-browser-server requires the websockets Python library (pip install websockets) and have
-# been tested with Python 3.7. Earlier versions may work.
+# GLVis is free software; you can redistribute it and/or modify it under the
+# terms of the BSD-3 license. We welcome feedback and contributions, see file
+# CONTRIBUTING.md for details.
+
+# The glvis-browser-server script is an MFEM socket-to-websocket forwarder to
+# make it easier to use glvis-js as a viewer for inline MFEM visualization.
 #
+# The input is assumed to be on the default MFEM port of 19916, the default host
+# and websocket port is localhost:8080. The glvis-browser-server script must be
+# run before opening the web client or sending data to the MFEM socket.
+#
+# The script requires the websockets Python library (pip install websockets) and
+# have been tested with Python 3.7. Earlier versions may work.
 
 import argparse
 import asyncio
@@ -35,8 +48,7 @@ async def ws_handler(queue, websocket, path):
             websockets.exceptions.ConnectionClosedOK,
             websockets.exceptions.ConnectionClosedError,
         ):
-            # if there is only one message we can requeue it, otherwise
-            # drop it
+            # if there is only one message we can requeue it, otherwise drop it
             if queue.empty():
                 queue.put_nowait(msg)
             break

--- a/src/glvis.js
+++ b/src/glvis.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b9116b41a835b17582a79d06bcb13b5128c9d327067641f2f45cbdafd9ab0532
-size 5354102
+oid sha256:32a674994b271fd2d873dfc72beac8e9b6b448982614ca5911105f007ba1f5ae
+size 5363066

--- a/src/index.js
+++ b/src/index.js
@@ -137,7 +137,8 @@
 
     async updateStream(stream) {
       if (!this.emsetup_) {
-        return displayStream(stream);
+        this.displayStream(stream);
+        return;
       }
       const index = stream.indexOf("\n");
       const data_type = stream.substr(0, index);
@@ -145,7 +146,7 @@
       var g = await this.emglv_;
       if (g.updateVisualization(data_type, data_str) != 0) {
         console.log("unable to update stream, starting a new one");
-        return displayStream(stream);
+        this.display(data_type, data_str);
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -135,6 +135,20 @@
       this.display(data_type, data_str);
     }
 
+    async updateStream(stream) {
+      if (!this.emsetup_) {
+        return displayStream(stream);
+      }
+      const index = stream.indexOf("\n");
+      const data_type = stream.substr(0, index);
+      const data_str = stream.substr(index + 1);
+      var g = await this.emglv_;
+      if (g.updateVisualization(data_type, data_str) != 0) {
+        console.log("unable to update stream, starting a new one");
+        return displayStream(stream);
+      }
+    }
+
     sendKey(key) {
       if (this.canvas_ === undefined) {
         var e = new KeyboardEvent("keypress", {

--- a/src/versions.js
+++ b/src/versions.js
@@ -1,5 +1,5 @@
 const versions = {
   emscripten: "2.0.11",
   mfem: "v4.2-370-gf4c2758e8",
-  glvis: "v4.0-49-g230df6b",
+  glvis: "v4.0-57-g585e34f",
 };


### PR DESCRIPTION
Use new `emglvis.updateVisualization` from https://github.com/GLVis/glvis/pull/143 to handle socket updates so that keys are preserved.
Adds "Pause/Resume" button to the "Setup" menu.
Rename `m2w.py` to `glvis-browser-server`
Fix memory leak in `startVisualization`

This PR address the two "Major" issues in https://github.com/GLVis/glvis-js/pull/1

- [x] Update *glvis.js* once https://github.com/GLVis/glvis/pull/143 is merged