### PR TITLE
Fix HiDPI scaling issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,8 @@
 
     setCanvasSize(width, height) {
       const pixel_ratio = window.devicePixelRatio || 1;
+      this.logical_width = width;
+      this.logical_height = height;
       this.canvas_.style.width = `${width}px`;
       this.canvas_.style.height = `${height}px`;
       this.canvas_.width = Math.floor(width * pixel_ratio);
@@ -130,8 +132,8 @@
       g.startVisualization(
         data_str,
         data_type,
-        parseInt(this.canvas_.style.width),
-        parseInt(this.canvas_.style.height)
+        this.logical_width,
+        this.logical_height
       );
       this.new_stream_callbacks.forEach((f) => f(this));
       this._startVis(g);


### PR DESCRIPTION
SDL expects logical pixel dimensions for the window size i.e. not scaled by the device pixel ratio. So instead of passing in `canvas.width` and `canvas.height` which gives us an unwanted extra dpr scaling, we pass in the logical CSS dimensions.