### PR TITLE
Draft: Parallel streams

### DIFF
--- a/glvis-browser-server
+++ b/glvis-browser-server
@@ -25,6 +25,7 @@ import argparse
 import asyncio
 import logging
 import websockets
+import json
 
 logger = logging.getLogger("websockets.server")
 logger.setLevel(logging.ERROR)
@@ -38,9 +39,12 @@ args = parser.parse_args()
 
 
 async def ws_handler(queue, websocket, path):
+    """Write serial stream messages or encode and write stream-list messages"""
     print("websocket client connected")
     while True:
         msg = await queue.get()
+        if type(msg) == list:
+            msg = json.dumps(msg)
         print(f"sending {msg[0:min(len(msg), 20)]}...")
         try:
             await websocket.send(msg)
@@ -56,6 +60,7 @@ async def ws_handler(queue, websocket, path):
 
 
 async def mfem_handler(queue, reader, writer, timeout=1, block_size=1024):
+    """Read and queue streams from mfem"""
     peername = writer.get_extra_info("peername")
     if peername is not None:
         client, port = peername
@@ -69,7 +74,8 @@ async def mfem_handler(queue, reader, writer, timeout=1, block_size=1024):
             block = await asyncio.wait_for(reader.read(block_size), timeout)
             if not block:
                 break
-            idx = block.rfind(b"solution")
+            idx = block.rfind(b"parallel")
+            if idx == -1: idx = block.rfind(b"solution")
             if (idx != -1 and msg) or idx > 0:
                 msg += block[:idx]
                 queue.put_nowait(msg.decode())
@@ -87,6 +93,7 @@ async def mfem_handler(queue, reader, writer, timeout=1, block_size=1024):
 
 
 async def create_mfem_server(queue):
+    """Helper method: start mfem_handler server"""
     print("mfem server: starting")
 
     async def handler_wrap(reader, writer):
@@ -99,17 +106,54 @@ async def create_mfem_server(queue):
     print("mfem server: complete")
 
 
+async def parallel_message_builder(pqueues, ws_queue):
+    """Process queued parallel streams and build/queue stream-list messages"""
+    print("parallel_message_builder: starting")
+    try:
+        while True:
+            stream_list = []
+            for q in pqueues:
+                stream_list.append(await q.get())
+            ws_queue.put_nowait(stream_list)
+    except asyncio.CancelledError:
+        print("parallel_message_builder: stopping")
+
+
+async def message_handler(mfem_queue, ws_queue):
+    """Forward serial stream messages and queue parallel streams"""
+    print("message handler: starting")
+    pqueues = ptask = None
+    while True:
+        msg = await mfem_queue.get()
+        if msg.startswith("parallel"):
+            info = msg[:msg.find("\n")].split(" ")
+            nproc = int(info[1])
+            rank = int(info[2])
+            if pqueues is None or len(pqueues) != nproc:
+                print(f"message_handler: now handling parallel nproc={nproc} messages")
+                pqueues = [asyncio.Queue() for i in range(nproc)]
+                if ptask is not None: ptask.cancel()
+                ptask = asyncio.create_task(parallel_message_builder(pqueues, ws_queue))
+            pqueues[rank].put_nowait(msg)
+        else:
+            ws_queue.put_nowait(msg)
+    await ptask
+
+
 async def main():
-    queue = asyncio.Queue()
+    mfem_queue = asyncio.Queue()
+    ws_queue = asyncio.Queue()
 
     async def ws_handler_wrap(websocket, path):
-        await ws_handler(queue, websocket, path)
+        await ws_handler(ws_queue, websocket, path)
 
     ws_server = websockets.serve(ws_handler_wrap, "0.0.0.0", args.ws_port)
-    mfem_server = asyncio.create_task(create_mfem_server(queue))
+    mfem_server = asyncio.create_task(create_mfem_server(mfem_queue))
+    msg_handler = asyncio.create_task(message_handler(mfem_queue, ws_queue))
 
     await ws_server
     await mfem_server
+    await msg_handler
 
 
 asyncio.run(main())

--- a/live/index.html
+++ b/live/index.html
@@ -986,7 +986,7 @@
             this.glvIsInitializing = false;
           });
         } else if (typeof example_stream !== "undefined") {
-          this.glv.displayStream(example_stream).then(() => {
+          this.glv.display(example_stream).then(() => {
             this.glvIsInitializing = false;
           });
         } else {
@@ -1054,8 +1054,10 @@
           while (this.glvStreamIsPaused) {
             await new Promise((r) => setTimeout(r, 500));
           }
-          await this.glv.updateStream(msg);
-          if (msg.endsWith("pause\n")) {
+          // msg might be json, if it starts with `[' we know it's a json list...
+          if (msg[0] == '[') { msg = JSON.parse(msg); }
+          await this.glv.update(msg);
+          if (typeof(msg) == "string" && msg.endsWith("pause\n") || Array.isArray(msg) && msg[0].endsWith("pause\n")) {
             this.glvStreamIsPaused = true;
             console.log("pausing");
           }

--- a/live/index.html
+++ b/live/index.html
@@ -1055,9 +1055,14 @@
             await new Promise((r) => setTimeout(r, 500));
           }
           // msg might be json, if it starts with `[' we know it's a json list...
-          if (msg[0] == '[') { msg = JSON.parse(msg); }
+          if (msg[0] == "[") {
+            msg = JSON.parse(msg);
+          }
           await this.glv.update(msg);
-          if (typeof(msg) == "string" && msg.endsWith("pause\n") || Array.isArray(msg) && msg[0].endsWith("pause\n")) {
+          if (
+            (typeof msg == "string" && msg.endsWith("pause\n")) ||
+            (Array.isArray(msg) && msg[0].endsWith("pause\n"))
+          ) {
             this.glvStreamIsPaused = true;
             console.log("pausing");
           }

--- a/src/index.js
+++ b/src/index.js
@@ -130,43 +130,46 @@
       window.requestAnimationFrame(iterVis);
     }
 
-    async display(data_type, data_str) {
+    async _display(data, is_update, ...args) {
+      var g = await this.emglv_;
+      if (Array.isArray(data)) {
+        const f = is_update ? g.updateParallelStreams : g.displayParallelStreams;
+        // TODO: this seems expensive, there must be a better way..
+        var streams = new g.StringArray();
+        data.forEach(s => streams.push_back(s));
+        const stat = f(streams, ...args);
+        streams.delete();
+        return stat;
+      }
+      else if (typeof(data) == "string") {
+        const f = is_update ? g.updateStream : g.displayStream;
+        return f(data, ...args);
+      }
+      else {
+        throw `unsupported data type ${typeof(data)}`;
+      }
+    }
+
+
+    async display(data) {
       var g = await this.emglv_;
       this._setupEmGlvis(g);
-      g.startVisualization(
-        data_str,
-        data_type,
-        this.logical_width_,
-        this.logical_height_
-      );
+
+      await this._display(data, false, this.logical_width_, this.logical_height_);
+
       this.new_stream_callbacks.forEach((f) => f(this));
       this._startVis(g);
     }
 
-    async displayStream(stream) {
-      const index = stream.indexOf("\n");
-      const data_type = stream.substr(0, index);
-      const data_str = stream.substr(index + 1);
-      await this.display(data_type, data_str);
-    }
-
-    async update(data_type, data_str) {
+    async update(data) {
       if (!this.emsetup_) {
-        this.display(data_type, data_str);
+        this.display(data);
         return;
       }
-      var g = await this.emglv_;
-      if (g.updateVisualization(data_type, data_str) != 0) {
+      if (await this._display(data, true) != 0) {
         console.log("unable to update stream, starting a new one");
-        this.display(data_type, data_str);
+        this.display(data);
       }
-    }
-
-    async updateStream(stream) {
-      const index = stream.indexOf("\n");
-      const data_type = stream.substr(0, index);
-      const data_str = stream.substr(index + 1);
-      await this.update(data_type, data_str);
     }
 
     async sendKey(key, ctrl = false, shift = false, alt = false) {
@@ -201,13 +204,13 @@
         return;
       }
       console.log(`loading ${url}`);
-      await this.displayStream(text);
+      await this.display(text);
     }
 
     async loadStream(e) {
       const filename = e.target.files[0];
       const data = await new Response(filename).text();
-      await this.displayStream(data);
+      await this.display(data);
     }
 
     setTouchDevice(status) {

--- a/src/index.js
+++ b/src/index.js
@@ -133,29 +133,33 @@
     async _display(data, is_update, ...args) {
       var g = await this.emglv_;
       if (Array.isArray(data)) {
-        const f = is_update ? g.updateParallelStreams : g.displayParallelStreams;
+        const f = is_update
+          ? g.updateParallelStreams
+          : g.displayParallelStreams;
         // TODO: this seems expensive, there must be a better way..
         var streams = new g.StringArray();
-        data.forEach(s => streams.push_back(s));
+        data.forEach((s) => streams.push_back(s));
         const stat = f(streams, ...args);
         streams.delete();
         return stat;
-      }
-      else if (typeof(data) == "string") {
+      } else if (typeof data == "string") {
         const f = is_update ? g.updateStream : g.displayStream;
         return f(data, ...args);
-      }
-      else {
-        throw `unsupported data type ${typeof(data)}`;
+      } else {
+        throw `unsupported data type ${typeof data}`;
       }
     }
-
 
     async display(data) {
       var g = await this.emglv_;
       this._setupEmGlvis(g);
 
-      await this._display(data, false, this.logical_width_, this.logical_height_);
+      await this._display(
+        data,
+        false,
+        this.logical_width_,
+        this.logical_height_
+      );
 
       this.new_stream_callbacks.forEach((f) => f(this));
       this._startVis(g);
@@ -166,7 +170,7 @@
         this.display(data);
         return;
       }
-      if (await this._display(data, true) != 0) {
+      if ((await this._display(data, true)) != 0) {
         console.log("unable to update stream, starting a new one");
         this.display(data);
       }


### PR DESCRIPTION
Adds support for parallel streams.

`glvis-browser-server` will now handle messages with the `parallel <nproc> <rank>` header; when it sees one it will wait for/build a list with 1 message from each rank then jsonify and write the message. The behavior for serial messages remains unchanged.

The `live` page with look for json array messages (those that start with `[`) and decode them.

The stream-list messages are repacked into an Emscripten `std::vector<std::string>` wrapper (`StringArray`) then passed to the new `displayParallelStreams`/`updateParallelStreams` methods.

The `data_type` processing was removed from the web side and now lives in the compiled code.

Depends on https://github.com/GLVis/glvis/pull/235