### PR TITLE
CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,11 +75,13 @@ jobs:
         ref: ${{ env.glvis-ref }}
         path: glvis
 
-    - name: Install glvis-js (also installs mfem + glvis)
+    - name: Checkout glvis-js
       uses: actions/checkout@v4
       with:
         repository: glvis/glvis-js
         submodules: recursive
+
+    - name: Install glvis-js (also installs mfem + glvis)
       run: | 
         make install -j 4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,6 @@ jobs:
     - name: Install glvis-js
       run: | 
         git submodule update --init --recursive
-        curl -s -o ../glvis/OpenSans.ttf https://github.com/googlefonts/opensans/raw/main/fonts/ttf/OpenSans-Regular.ttf
         make install -j 4
 
     # ---------------------------------------------------------------------------------

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,6 @@ jobs:
 
     - name: Install glvis-js
       run: | 
-        cd glvis-js
         git submodule update --init --recursive
         curl -s -o ../glvis/OpenSans.ttf https://raw.githubusercontent.com/google/fonts/master/apache/opensans/OpenSans-Regular.ttf
         make install -j 4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         git clone https://github.com/mfem/mfem.git
         cd mfem
         git checkout ${{ env.mfem-ref }}
-        make -j 4
+        make serial -j 4
 
     - name: Install glvis
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,8 @@ jobs:
     - name: Install emscripten
       uses: actions/checkout@v4
       with:
-        repository: 'emscripten-core/emsdk'
-        ref: ${{ env.emscripten-version }}
+        repository: emscripten-core/emsdk
+        path: emsdk
       run: |
         ./emsdk install ${{ env.emscripten-version }}
         ./emsdk activate ${{ env.emscripten-version }}
@@ -64,20 +64,22 @@ jobs:
     - name: Checkout mfem
       uses: actions/checkout@v4
       with:
-        repository: 'mfem/mfem'
+        repository: mfem/mfem
         ref: ${{ env.mfem-ref }}
+        path: mfem
 
     - name: Checkout glvis
       uses: actions/checkout@v4
       with:
-        repository: 'glvis/glvis'
+        repository: glvis/glvis
         ref: ${{ env.glvis-ref }}
+        path: glvis
 
     - name: Install glvis-js (also installs mfem + glvis)
       uses: actions/checkout@v4
       with:
-        repository: 'glvis/glvis-js'
-        submodules: true
+        repository: glvis/glvis-js
+        submodules: recursive
       run: | 
         make install -j 4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,12 @@ jobs:
     # ---------------------------------------------------------------------------------
     # Generate an artifact
     # ---------------------------------------------------------------------------------
-    - name: Upload Artifact
+    - name: Print artifact info
+      run: | 
+        cat glvis-js/src/versions.js
+        sha256sum glvis-js/src/*
+
+    - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
           name: glvis-js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Install emscripten
       uses: actions/checkout@v4
       with:
-        repository: 'https://github.com/emscripten-core/emsdk.git'
+        repository: 'emscripten-core/emsdk'
         ref: ${{ env.emscripten-version }}
       run: |
         ./emsdk install ${{ env.emscripten-version }}
@@ -64,14 +64,19 @@ jobs:
     - name: Checkout mfem
       uses: actions/checkout@v4
       with:
-        repository: 'https://github.com/mfem/mfem.git'
+        repository: 'mfem/mfem'
         ref: ${{ env.mfem-ref }}
 
-    - name: Install glvis (also installs mfem + glvis)
+    - name: Checkout glvis
       uses: actions/checkout@v4
       with:
-        repository: https://github.com/glvis/glvis.git
+        repository: 'glvis/glvis'
         ref: ${{ env.glvis-ref }}
+
+    - name: Install glvis-js (also installs mfem + glvis)
+      uses: actions/checkout@v4
+      with:
+        repository: 'glvis/glvis-js'
         submodules: true
       run: | 
         make install -j 4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ on:
         default: 'master'
       emscripten-version:
         type: string
+        # We use 3.1.51 because later versions give compiler errors
+        # (possibly related to https://github.com/emscripten-core/emscripten/issues/21128)
         default: '3.1.51'
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
     # ---------------------------------------------------------------------------------
     - name: Install glvis dependencies
       run: |
-        apt-get install libfontconfig1-dev libfreetype-dev libsdl2-dev \
+        sudo apt-get install libfontconfig1-dev libfreetype-dev libsdl2-dev \
         libglew-dev libglm-dev libpng-dev
 
     - name: Install emscripten

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,9 +68,12 @@ jobs:
         git checkout ${{ inputs.glvis-ref }}
         make -j 4
 
-    - name: Install glvis-js
+    - name: Checkout glvis-js
       uses: actions/checkout@v4
+
+    - name: Install glvis-js
       run: | 
+        cd glvis-js
         git submodule update --init --recursive
         curl -s -o ../glvis/OpenSans.ttf https://raw.githubusercontent.com/google/fonts/master/apache/opensans/OpenSans-Regular.ttf
         make install -j 4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,16 +16,22 @@ on:
         # We use 3.1.51 because later versions give compiler errors
         # (possibly related to https://github.com/emscripten-core/emscripten/issues/21128)
         default: '3.1.51'
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      mfem-ref: ${{ github.event_name == 'pull_request' && 'master' || inputs.mfem-ref }}
+      glvis-ref: ${{ github.event_name == 'pull_request' && 'master' || inputs.glvis-ref }}
+      emscripten-version: ${{ github.event_name == 'pull_request' && '3.1.51' || inputs.emscripten-version }}
+
     name: >-
         build glvis-js |
-        mfem=${{ inputs.mfem-ref }} | 
-        glvis=${{ inputs.glvis-ref }} | 
-        emcc=${{ inputs.emscripten-version }}
+        mfem=${{ env.mfem-ref }} | 
+        glvis=${{ env.glvis-ref }} | 
+        emcc=${{ env.emscripten-version }}
 
     steps:
     # ---------------------------------------------------------------------------------
@@ -51,8 +57,8 @@ jobs:
     - name: Install emscripten
       run: |
         cd emsdk
-        ./emsdk install ${{ inputs.emscripten-version }}
-        ./emsdk activate ${{ inputs.emscripten-version }}
+        ./emsdk install ${{ env.emscripten-version }}
+        ./emsdk activate ${{ env.emscripten-version }}
         echo "${GITHUB_WORKSPACE}/emsdk" >> $GITHUB_PATH
         echo "${GITHUB_WORKSPACE}/emsdk/upstream/emscripten" >> $GITHUB_PATH
 
@@ -60,14 +66,14 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: mfem/mfem
-        ref: ${{ inputs.mfem-ref }}
+        ref: ${{ env.mfem-ref }}
         path: mfem
 
     - name: Checkout glvis
       uses: actions/checkout@v4
       with:
         repository: glvis/glvis
-        ref: ${{ inputs.glvis-ref }}
+        ref: ${{ env.glvis-ref }}
         path: glvis
 
     - name: Install glvis-js (also installs mfem + glvis)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,85 @@
+# build.yml
+
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      mfem-ref:
+        type: string
+        default: 'master'
+      glvis-ref:
+        type: string
+        default: 'master'
+      emscripten-version:
+        type: string
+        default: 'latest'
+  workflow_dispatch:
+    inputs:
+      mfem-ref:
+        type: string
+        default: 'master'
+      glvis-ref:
+        type: string
+        default: 'master'
+      emscripten-version:
+        type: string
+        default: 'latest'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    name: >-
+      mfem=${{ inputs.mfem-ref }} | 
+      glvis=${{ inputs.glvis-ref }} | 
+      emcc=${{ inputs.emscripten-version }}
+
+    steps:
+    # ---------------------------------------------------------------------------------
+    # Install glvis-js and dependencies
+    # ---------------------------------------------------------------------------------
+    - name: Install glvis dependencies
+      run: |
+        apt-get install libfontconfig1-dev libfreetype-dev libsdl2-dev \
+        libglew-dev libglm-dev libpng-dev
+
+    - name: Install emscripten
+      run: |
+        git clone https://github.com/emscripten-core/emsdk.git
+        cd emsdk
+        git pull
+        ./emsdk install ${{ inputs.emscripten-version }}
+        ./emsdk activate ${{ inputs.emscripten-version }}
+        source emsdk_env.sh
+
+    - name: Install mfem
+      run: |
+        git clone https://github.com/mfem/mfem.git
+        cd mfem
+        git checkout ${{ inputs.mfem-ref }}
+        make -j 4
+
+    - name: Install glvis
+      run: |
+        git clone https://github.com/glvis/glvis.git
+        cd glvis
+        git checkout ${{ inputs.glvis-ref }}
+        make -j 4
+
+    - name: Install glvis-js
+      uses: actions/checkout@v4
+      run: | 
+        git submodule update --init --recursive
+        curl -s -o ../glvis/OpenSans.ttf https://raw.githubusercontent.com/google/fonts/master/apache/opensans/OpenSans-Regular.ttf
+        make install -j 4
+
+    # ---------------------------------------------------------------------------------
+    # Generate an artifact
+    # ---------------------------------------------------------------------------------
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+          name: glvis-js
+          path: glvis-js/src
+          retention-days: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,9 @@ jobs:
 
     name: >-
         build glvis-js |
-        mfem=${{ env.mfem-ref }} | 
-        glvis=${{ env.glvis-ref }} | 
-        emcc=${{ env.emscripten-version }}
+        mfem=${{ github.event_name == 'pull_request' && 'master' || inputs.mfem-ref }} | 
+        glvis=${{ github.event_name == 'pull_request' && 'master' || inputs.glvis-ref }} | 
+        emcc=${{ github.event_name == 'pull_request' && '3.1.51' || inputs.emscripten-version }}
 
     steps:
     # ---------------------------------------------------------------------------------

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,11 +51,13 @@ jobs:
         sudo apt-get install libfontconfig1-dev libfreetype-dev libsdl2-dev \
         libglew-dev libglm-dev libpng-dev
 
-    - name: Install emscripten
+    - name: Checkout emscripten
       uses: actions/checkout@v4
       with:
         repository: emscripten-core/emsdk
         path: emsdk
+
+    - name: Install emscripten
       run: |
         ./emsdk install ${{ env.emscripten-version }}
         ./emsdk activate ${{ env.emscripten-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
 
     - name: Install emscripten
       run: |
+        cd emsdk
         ./emsdk install ${{ env.emscripten-version }}
         ./emsdk activate ${{ env.emscripten-version }}
         source emsdk_env.sh
@@ -82,9 +83,11 @@ jobs:
       with:
         repository: glvis/glvis-js
         submodules: recursive
+        path: glvis-js
 
     - name: Install glvis-js (also installs mfem + glvis)
       run: | 
+        cd glvis-js
         make install -j 4
 
     # ---------------------------------------------------------------------------------

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Install glvis-js
       run: | 
         git submodule update --init --recursive
-        curl -s -o ../glvis/OpenSans.ttf https://github.com/googlefonts/opensans/blob/main/fonts/ttf/OpenSans-Regular.ttf
+        curl -s -o ../glvis/OpenSans.ttf https://github.com/googlefonts/opensans/raw/main/fonts/ttf/OpenSans-Regular.ttf
         make install -j 4
 
     # ---------------------------------------------------------------------------------

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
     env:
       mfem-ref: 'master'
       glvis-ref: 'master'
-      emscripten-version: 'latest'
+      emscripten-version: '3.1.51'
 
     steps:
     # ---------------------------------------------------------------------------------

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@
 name: Build
 
 on:
+  pull_request:
   workflow_call:
     inputs:
       mfem-ref:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,18 +3,6 @@
 name: Build
 
 on:
-  pull_request:
-  workflow_call:
-    inputs:
-      mfem-ref:
-        type: string
-        default: 'master'
-      glvis-ref:
-        type: string
-        default: 'master'
-      emscripten-version:
-        type: string
-        default: 'latest'
   workflow_dispatch:
     inputs:
       mfem-ref:
@@ -25,22 +13,17 @@ on:
         default: 'master'
       emscripten-version:
         type: string
-        default: 'latest'
+        default: '3.1.51'
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
-    name: testing
-    #>-
-        #      mfem=${{ inputs.mfem-ref }} | 
-        #      glvis=${{ inputs.glvis-ref }} | 
-        #      emcc=${{ inputs.emscripten-version }}
-
-    env:
-      mfem-ref: 'master'
-      glvis-ref: 'master'
-      emscripten-version: '3.1.51'
+    name: >-
+        build glvis-js |
+        mfem=${{ inputs.mfem-ref }} | 
+        glvis=${{ inputs.glvis-ref }} | 
+        emcc=${{ inputs.emscripten-version }}
 
     steps:
     # ---------------------------------------------------------------------------------
@@ -66,8 +49,8 @@ jobs:
     - name: Install emscripten
       run: |
         cd emsdk
-        ./emsdk install ${{ env.emscripten-version }}
-        ./emsdk activate ${{ env.emscripten-version }}
+        ./emsdk install ${{ inputs.emscripten-version }}
+        ./emsdk activate ${{ inputs.emscripten-version }}
         echo "${GITHUB_WORKSPACE}/emsdk" >> $GITHUB_PATH
         echo "${GITHUB_WORKSPACE}/emsdk/upstream/emscripten" >> $GITHUB_PATH
 
@@ -75,14 +58,14 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: mfem/mfem
-        ref: ${{ env.mfem-ref }}
+        ref: ${{ inputs.mfem-ref }}
         path: mfem
 
     - name: Checkout glvis
       uses: actions/checkout@v4
       with:
         repository: glvis/glvis
-        ref: ${{ env.glvis-ref }}
+        ref: ${{ inputs.glvis-ref }}
         path: glvis
 
     - name: Install glvis-js (also installs mfem + glvis)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,34 +52,28 @@ jobs:
         libglew-dev libglm-dev libpng-dev
 
     - name: Install emscripten
+      uses: actions/checkout@v4
+      with:
+        repository: 'https://github.com/emscripten-core/emsdk.git'
+        ref: ${{ env.emscripten-version }}
       run: |
-        git clone https://github.com/emscripten-core/emsdk.git
-        cd emsdk
-        git pull
         ./emsdk install ${{ env.emscripten-version }}
         ./emsdk activate ${{ env.emscripten-version }}
         source emsdk_env.sh
 
-    - name: Install mfem
-      run: |
-        git clone https://github.com/mfem/mfem.git
-        cd mfem
-        git checkout ${{ env.mfem-ref }}
-        make serial -j 4
-
-    - name: Install glvis
-      run: |
-        git clone https://github.com/glvis/glvis.git
-        cd glvis
-        git checkout ${{ env.glvis-ref }}
-        make -j 4
-
-    - name: Checkout glvis-js
+    - name: Checkout mfem
       uses: actions/checkout@v4
+      with:
+        repository: 'https://github.com/mfem/mfem.git'
+        ref: ${{ env.mfem-ref }}
 
-    - name: Install glvis-js
+    - name: Install glvis (also installs mfem + glvis)
+      uses: actions/checkout@v4
+      with:
+        repository: https://github.com/glvis/glvis.git
+        ref: ${{ env.glvis-ref }}
+        submodules: true
       run: | 
-        git submodule update --init --recursive
         make install -j 4
 
     # ---------------------------------------------------------------------------------

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Install glvis-js
       run: | 
         git submodule update --init --recursive
-        curl -s -o ../glvis/OpenSans.ttf https://raw.githubusercontent.com/google/fonts/master/apache/opensans/OpenSans-Regular.ttf
+        curl -s -o ../glvis/OpenSans.ttf https://github.com/googlefonts/opensans/blob/main/fonts/ttf/OpenSans-Regular.ttf
         make install -j 4
 
     # ---------------------------------------------------------------------------------

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,8 @@ jobs:
         cd emsdk
         ./emsdk install ${{ env.emscripten-version }}
         ./emsdk activate ${{ env.emscripten-version }}
-        source emsdk_env.sh
+        echo "${GITHUB_WORKSPACE}/emsdk" >> $GITHUB_PATH
+        echo "${GITHUB_WORKSPACE}/emsdk/upstream/emscripten" >> $GITHUB_PATH
 
     - name: Checkout mfem
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,10 +31,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    name: >-
-      mfem=${{ inputs.mfem-ref }} | 
-      glvis=${{ inputs.glvis-ref }} | 
-      emcc=${{ inputs.emscripten-version }}
+    name: testing
+    #>-
+        #      mfem=${{ inputs.mfem-ref }} | 
+        #      glvis=${{ inputs.glvis-ref }} | 
+        #      emcc=${{ inputs.emscripten-version }}
+
+    env:
+      mfem-ref: 'master'
+      glvis-ref: 'master'
+      emscripten-version: 'latest'
 
     steps:
     # ---------------------------------------------------------------------------------
@@ -50,22 +56,22 @@ jobs:
         git clone https://github.com/emscripten-core/emsdk.git
         cd emsdk
         git pull
-        ./emsdk install ${{ inputs.emscripten-version }}
-        ./emsdk activate ${{ inputs.emscripten-version }}
+        ./emsdk install ${{ env.emscripten-version }}
+        ./emsdk activate ${{ env.emscripten-version }}
         source emsdk_env.sh
 
     - name: Install mfem
       run: |
         git clone https://github.com/mfem/mfem.git
         cd mfem
-        git checkout ${{ inputs.mfem-ref }}
+        git checkout ${{ env.mfem-ref }}
         make -j 4
 
     - name: Install glvis
       run: |
         git clone https://github.com/glvis/glvis.git
         cd glvis
-        git checkout ${{ inputs.glvis-ref }}
+        git checkout ${{ env.glvis-ref }}
         make -j 4
 
     - name: Checkout glvis-js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,12 @@ jobs:
     # ---------------------------------------------------------------------------------
     # Install glvis-js and dependencies
     # ---------------------------------------------------------------------------------
+    - name: Checkout glvis-js
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        path: glvis-js
+
     - name: Install glvis dependencies
       run: |
         sudo apt-get install libfontconfig1-dev libfreetype-dev libsdl2-dev \
@@ -77,13 +83,6 @@ jobs:
         repository: glvis/glvis
         ref: ${{ env.glvis-ref }}
         path: glvis
-
-    - name: Checkout glvis-js
-      uses: actions/checkout@v4
-      with:
-        repository: glvis/glvis-js
-        submodules: recursive
-        path: glvis-js
 
     - name: Install glvis-js (also installs mfem + glvis)
       run: | 

--- a/OFL.txt
+++ b/OFL.txt
@@ -1,0 +1,88 @@
+Copyright 2020 The Open Sans Project Authors (https://github.com/googlefonts/opensans)
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to
+provide a free and open framework in which fonts may be shared and
+improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software
+components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to,
+deleting, or substituting -- in part or in whole -- any of the
+components of the Original Version, by changing formats or by porting
+the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed,
+modify, redistribute, and sell modified and unmodified copies of the
+Font Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in
+Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the
+corresponding Copyright Holder. This restriction only applies to the
+primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created using
+the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ open basic.html
 
    ```
    cd glvis-js
-   curl -s -o ../glvis/OpenSans.ttf https://raw.githubusercontent.com/google/fonts/master/apache/opensans/OpenSans-Regular.ttf
+   curl -s -o ../glvis/OpenSans.ttf https://github.com/googlefonts/opensans/blob/main/fonts/ttf/OpenSans-Regular.ttf
    ```
 
 5. Build:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ open basic.html
 
    ```
    cd glvis-js
-   curl -s -o ../glvis/OpenSans.ttf https://github.com/googlefonts/opensans/blob/main/fonts/ttf/OpenSans-Regular.ttf
+   curl -s -o ../glvis/OpenSans.ttf https://github.com/googlefonts/opensans/raw/main/fonts/ttf/OpenSans-Regular.ttf
    ```
 
 5. Build:

--- a/README.md
+++ b/README.md
@@ -55,21 +55,14 @@ open basic.html
    git submodule update --init --recursive
    ```
 
-4. Get a copy of _OpenSans.ttf_ and put it in the GLVis root directory. For example
-
-   ```
-   cd glvis-js
-   curl -s -o ../glvis/OpenSans.ttf https://github.com/googlefonts/opensans/raw/main/fonts/ttf/OpenSans-Regular.ttf
-   ```
-
-5. Build:
+4. Build:
 
    ```
    make realclean # or just clean if you don't want to rebuild mfem
    make install -j
    ```
 
-6. Patch glvis.js (temporary):
+5. Patch glvis.js (temporary):
 
    Edit src/glvis.js and add `return 0;` to the top of `_JSEvents_requestFullscreen` (see Known
    Issues)

--- a/makefile
+++ b/makefile
@@ -30,6 +30,7 @@ $(LIB_MFEM):
 		BUILD_DIR=$(MFEM_BUILD_DIR) serial AR=$(EMAR) ARFLAGS=rcs RANLIB=echo
 
 $(LIB_GLVIS_JS): $(LIB_MFEM)
+	@$(MAKE) get_opensans
 	@$(MAKE) -C $(GLVIS_DIR) GLM_DIR=$(GLM_ROOT) MFEM_DIR=$(MFEM_BUILD_DIR) \
 		GLVIS_USE_LOGO=NO GLVIS_USE_LIBPNG=YES js
 
@@ -65,10 +66,11 @@ servelocal:
 	python3 -m http.server 8000 --bind 127.0.0.1
 
 get_opensans:
-	@if [ ! -f "../glvis/OpenSans.ttf" ]; then \
-		curl -s "https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" |\
-		grep -o "https://fonts.gstatic.com/[^)]*" |\
-		xargs -n 1 curl -s -o ../glvis/OpenSans.ttf; \
+	@if [ ! -f "$(GLVIS_DIR)/OpenSans.ttf" ]; then \
+		curl -s "https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" | \
+		grep -o "https://fonts.gstatic.com/[^)]*" | \
+		xargs -n 1 curl -s -o $(GLVIS_DIR)/OpenSans.ttf; \
+		echo "Downloaded OpenSans.ttf to $(GLVIS_DIR)"; \
 	else \
 		echo "GLVis already has OpenSans.ttf. Skipping download."; \
 	fi

--- a/makefile
+++ b/makefile
@@ -26,8 +26,9 @@ all: $(LIB_GLVIS_JS)
 
 $(LIB_MFEM):
 	# ranlib causes problems
-	@$(MAKE) -C $(MFEM_DIR) CXX=$(EMCXX) MFEM_TIMER_TYPE=0 \
-		BUILD_DIR=$(MFEM_BUILD_DIR) serial AR=$(EMAR) ARFLAGS=rcs RANLIB=echo
+	@$(MAKE) -C $(MFEM_DIR) BUILD_DIR=$(MFEM_BUILD_DIR) config CXX=$(EMCXX) \
+		MFEM_TIMER_TYPE=0 AR=$(EMAR) ARFLAGS=rcs RANLIB=echo 
+	$(MAKE) -C $(MFEM_BUILD_DIR) -j 4
 
 $(LIB_GLVIS_JS): $(LIB_MFEM)
 	@$(MAKE) get_opensans

--- a/makefile
+++ b/makefile
@@ -65,9 +65,13 @@ servelocal:
 	python3 -m http.server 8000 --bind 127.0.0.1
 
 get_opensans:
-	curl -s "https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" |\
-	grep -o "https://fonts.gstatic.com/[^)]*" |\
-	xargs -n 1 curl -s -o ../glvis/OpenSans.ttf
+	@if [ ! -f "../glvis/OpenSans.ttf" ]; then \
+		curl -s "https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" |\
+		grep -o "https://fonts.gstatic.com/[^)]*" |\
+		xargs -n 1 curl -s -o ../glvis/OpenSans.ttf; \
+	else \
+		echo "GLVis already has OpenSans.ttf. Skipping download."; \
+	fi
 
 realclean: clean
 	@test -d $(MFEM_BUILD_DUR) && rm -rf $(MFEM_BUILD_DIR)

--- a/makefile
+++ b/makefile
@@ -64,6 +64,11 @@ serve:
 servelocal:
 	python3 -m http.server 8000 --bind 127.0.0.1
 
+get_opensans:
+	curl -s "https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" |\
+	grep -o "https://fonts.gstatic.com/[^)]*" |\
+	xargs -n 1 curl -s -o ../glvis/OpenSans.ttf
+
 realclean: clean
 	@test -d $(MFEM_BUILD_DUR) && rm -rf $(MFEM_BUILD_DIR)
 


### PR DESCRIPTION
This PR
- Adds `build.yml` to build `glvis-js` and upload an artifact. Inputs are mfem-ref, glvis-ref, and emscripten-version
- Updates the `makefile`
  - Automatically download `OpenSans.ttf` using the new [API](https://fonts.google.com/specimen/Open+Sans) (raw.githubusercontent is deprecated/doesn't work anymore)
  - Fix `$(LIB_MFEM)` target (would produce a compile error unless `mfem` was previously configured)
- Adds `OFL.txt`, since open-sans is being bundled with the software.
- Updates `README`