### PR TITLE
Ci build 14802537003

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glvis",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A lightweight WebGL tool for accurate and flexible finite element visualization",
   "license": "BSD-3-Clause",
   "main": "src/index.js",

--- a/src/glvis.js
+++ b/src/glvis.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c2716b0bdc2213538922a43f6cdff9c6b7742f299a8ab82c9c37de4bfebeffd7
-size 7047121
+oid sha256:b1095765ae5020c242643a582c690890b6a4c49835c56c6d9b87628ef787912c
+size 8563937

--- a/src/versions.js
+++ b/src/versions.js
@@ -1,5 +1,5 @@
 const versions = {
   emscripten: "3.1.51",
-  mfem: "v4.7",
-  glvis: "v4.3.2",
+  mfem: "v4.8",
+  glvis: "v4.4",
 };


### PR DESCRIPTION
Updating build to `glvis` `v4.4`

Similar to #31 - tested `examples/basic.html` and `live/index.html` and both LGTM. Used `python -m http.server --bind localhost` to view the live version.