### PR TITLE
WSS mixed content fix for HTTPS

### DIFF
--- a/live/index.html
+++ b/live/index.html
@@ -1122,10 +1122,6 @@
             return;
           }
 
-          // Match the page's protocol so an https page uses wss (a ws socket
-          // would be blocked as mixed content).
-          const proto = window.location.protocol === "https:" ? "wss" : "ws";
-
           // A Host containing "/" is treated as a full "host[:port]/path"
           // address (e.g. behind a reverse proxy). A ws:// or wss:// URL is
           // also used as-is, ignoring the Port field.
@@ -1135,7 +1131,16 @@
           if (host.startsWith("ws://") || host.startsWith("wss://")) {
             addr = host;
           } else {
-            const hostUrl = new URL(`${proto}://${host}`);
+            const hostUrl = new URL(`http://${host}`);
+            const isLoopback = ["localhost", "127.0.0.1"].includes(
+              hostUrl.hostname,
+            );
+            // HTTPS pages need WSS for remote endpoints, but browsers permit
+            // the established local ws://localhost:8080 workflow.
+            const proto =
+              window.location.protocol === "https:" && !isLoopback
+                ? "wss"
+                : "ws";
             addr =
               host.includes("/") || hostUrl.port
                 ? `${proto}:\/\/${host}`

--- a/live/index.html
+++ b/live/index.html
@@ -214,16 +214,45 @@
                       <v-spacer></v-spacer>
                       <v-card-text>
                         <v-form ref="socketForm" lazy-validation>
+                          <v-radio-group
+                            v-model="socketConnectionMode"
+                            row
+                            hide-details
+                          >
+                            <v-radio
+                              label="Server address"
+                              value="address"
+                            ></v-radio>
+                            <v-radio
+                              label="WebSocket URL"
+                              value="url"
+                            ></v-radio>
+                          </v-radio-group>
                           <v-text-field
+                            v-if="socketConnectionMode === 'address'"
                             v-model="socketHost"
                             label="Host"
                             required
                           ></v-text-field>
                           <v-text-field
+                            v-if="socketConnectionMode === 'address'"
                             v-model="socketPort"
-                            label="Port"
+                            label="Port (optional)"
+                          ></v-text-field>
+                          <v-text-field
+                            v-if="socketConnectionMode === 'address'"
+                            v-model="socketPath"
+                            label="Path (optional)"
+                          ></v-text-field>
+                          <v-text-field
+                            v-if="socketConnectionMode === 'url'"
+                            v-model="socketUrl"
+                            label="WebSocket URL"
                             required
                           ></v-text-field>
+                          <div class="text-caption mb-2">
+                            {{ websocketAddress() }}
+                          </div>
                           <v-btn @click="connectWebsocket">
                             {{ connectWebsocketButtonLabel }}
                           </v-btn>
@@ -853,11 +882,11 @@
       host = "localhost";
     }
     const socket = new URLSearchParams(window.location.search).get("socket");
-    const socketHost = socket
-      ? socket.startsWith("/")
+    const socketHost =
+      socket && socket.startsWith("/")
         ? `${window.location.host}${socket}`
-        : socket
-      : host;
+        : host;
+    const socketUrl = socket && !socket.startsWith("/") ? socket : "";
     console.log(`host = ${host}`);
 
     const touch = matchMedia("(hover: none), (pointer: coarse)").matches;
@@ -873,8 +902,11 @@
         websocketDialogActive: false,
         logWindowActive: false,
         connectWebsocketButtonLabel: "Connect",
+        socketConnectionMode: socketUrl ? "url" : "address",
         socketHost: socketHost,
         socketPort: "8080",
+        socketPath: "/",
+        socketUrl: socketUrl,
         controlWindowActive: false,
         helpWindowActive: false,
         fullScreenMode: false,
@@ -1099,6 +1131,24 @@
         },
       },
       methods: {
+        websocketAddress: function () {
+          if (this.socketConnectionMode === "url") {
+            return this.socketUrl;
+          }
+
+          const isLoopback = ["localhost", "127.0.0.1"].includes(
+            this.socketHost,
+          );
+          const proto =
+            window.location.protocol === "https:" && !isLoopback ? "wss" : "ws";
+          const port = this.socketPort ? `:${this.socketPort}` : "";
+          const path = this.socketPath
+            ? this.socketPath.startsWith("/")
+              ? this.socketPath
+              : `/${this.socketPath}`
+            : "/";
+          return `${proto}://${this.socketHost}${port}${path}`;
+        },
         updateCanvasSize: function () {
           [w, h] = windowDim();
           this.glv.setSize(w, h);
@@ -1122,30 +1172,7 @@
             return;
           }
 
-          // A Host containing "/" is treated as a full "host[:port]/path"
-          // address (e.g. behind a reverse proxy). A ws:// or wss:// URL is
-          // also used as-is, ignoring the Port field.
-          const host = this.socketHost;
-          const port = this.socketPort;
-          let addr;
-          if (host.startsWith("ws://") || host.startsWith("wss://")) {
-            addr = host;
-          } else {
-            const hostUrl = new URL(`http://${host}`);
-            const isLoopback = ["localhost", "127.0.0.1"].includes(
-              hostUrl.hostname,
-            );
-            // HTTPS pages need WSS for remote endpoints, but browsers permit
-            // the established local ws://localhost:8080 workflow.
-            const proto =
-              window.location.protocol === "https:" && !isLoopback
-                ? "wss"
-                : "ws";
-            addr =
-              host.includes("/") || hostUrl.port
-                ? `${proto}:\/\/${host}`
-                : `${proto}:\/\/${host}:${port}`;
-          }
+          const addr = this.websocketAddress();
 
           console.log(`trying to connect websocket to ${addr}`);
           this.glvSocket = new WebSocket(addr);

--- a/live/index.html
+++ b/live/index.html
@@ -1137,7 +1137,7 @@
           }
 
           const isLoopback = ["localhost", "127.0.0.1"].includes(
-            this.socketHost,
+            this.socketHost
           );
           const proto =
             window.location.protocol === "https:" && !isLoopback ? "wss" : "ws";

--- a/live/index.html
+++ b/live/index.html
@@ -1127,13 +1127,16 @@
           // also used as-is, ignoring the Port field.
           const host = this.socketHost;
           const port = this.socketPort;
-          const hostUrl = new URL(`${proto}://${host}`);
-          const addr =
-            host.startsWith("ws://") || host.startsWith("wss://")
-              ? host
-              : host.includes("/") || hostUrl.port
+          let addr;
+          if (host.startsWith("ws://") || host.startsWith("wss://")) {
+            addr = host;
+          } else {
+            const hostUrl = new URL(`${proto}://${host}`);
+            addr =
+              host.includes("/") || hostUrl.port
                 ? `${proto}:\/\/${host}`
                 : `${proto}:\/\/${host}:${port}`;
+          }
 
           console.log(`trying to connect websocket to ${addr}`);
           this.glvSocket = new WebSocket(addr);

--- a/live/index.html
+++ b/live/index.html
@@ -1112,9 +1112,18 @@
             return;
           }
 
+          // Match the page's protocol so an https page uses wss (a ws socket
+          // would be blocked as mixed content).
+          const proto = window.location.protocol === "https:" ? "wss" : "ws";
+
+          // A Host containing "/" is treated as a full "host[:port]/path"
+          // address (e.g. behind a reverse proxy) and used as-is, ignoring the
+          // Port field. Otherwise Host and Port are combined as "host:port".
           const host = this.socketHost;
           const port = this.socketPort;
-          const addr = `ws:\/\/${host}:${port}`;
+          const addr = host.includes("/")
+            ? `${proto}:\/\/${host}`
+            : `${proto}:\/\/${host}:${port}`;
 
           console.log(`trying to connect websocket to ${addr}`);
           this.glvSocket = new WebSocket(addr);

--- a/live/index.html
+++ b/live/index.html
@@ -852,8 +852,11 @@
     if (host === "127.0.0.1" || host === "glvis.org") {
       host = "localhost";
     }
-    const socketHost = window.location.pathname.startsWith("/glvis/")
-      ? `${window.location.host}/glvis-ws`
+    const socket = new URLSearchParams(window.location.search).get("socket");
+    const socketHost = socket
+      ? socket.startsWith("/")
+        ? `${window.location.host}${socket}`
+        : socket
       : host;
     console.log(`host = ${host}`);
 
@@ -1120,13 +1123,17 @@
           const proto = window.location.protocol === "https:" ? "wss" : "ws";
 
           // A Host containing "/" is treated as a full "host[:port]/path"
-          // address (e.g. behind a reverse proxy) and used as-is, ignoring the
-          // Port field. Otherwise Host and Port are combined as "host:port".
+          // address (e.g. behind a reverse proxy). A ws:// or wss:// URL is
+          // also used as-is, ignoring the Port field.
           const host = this.socketHost;
           const port = this.socketPort;
-          const addr = host.includes("/")
-            ? `${proto}:\/\/${host}`
-            : `${proto}:\/\/${host}:${port}`;
+          const hostUrl = new URL(`${proto}://${host}`);
+          const addr =
+            host.startsWith("ws://") || host.startsWith("wss://")
+              ? host
+              : host.includes("/") || hostUrl.port
+                ? `${proto}:\/\/${host}`
+                : `${proto}:\/\/${host}:${port}`;
 
           console.log(`trying to connect websocket to ${addr}`);
           this.glvSocket = new WebSocket(addr);

--- a/live/index.html
+++ b/live/index.html
@@ -882,10 +882,10 @@
       host = "localhost";
     }
     const socket = new URLSearchParams(window.location.search).get("socket");
-    const socketHost =
-      socket && socket.startsWith("/")
-        ? `${window.location.host}${socket}`
-        : host;
+    const socketIsPath = socket && socket.startsWith("/");
+    const socketHost = socketIsPath ? window.location.host : host;
+    const socketPort = socketIsPath ? "" : "8080";
+    const socketPath = socketIsPath ? socket : "/";
     const socketUrl = socket && !socket.startsWith("/") ? socket : "";
     console.log(`host = ${host}`);
 
@@ -904,8 +904,8 @@
         connectWebsocketButtonLabel: "Connect",
         socketConnectionMode: socketUrl ? "url" : "address",
         socketHost: socketHost,
-        socketPort: "8080",
-        socketPath: "/",
+        socketPort: socketPort,
+        socketPath: socketPath,
         socketUrl: socketUrl,
         controlWindowActive: false,
         helpWindowActive: false,

--- a/live/index.html
+++ b/live/index.html
@@ -1080,6 +1080,10 @@
           await new Promise((r) => setTimeout(r, 50 + this.streamDelay * 10));
         });
 
+        if (socket) {
+          this.connectWebsocket();
+        }
+
         this.glvIsLoading = false;
       },
       watch: {

--- a/live/index.html
+++ b/live/index.html
@@ -852,6 +852,9 @@
     if (host === "127.0.0.1" || host === "glvis.org") {
       host = "localhost";
     }
+    const socketHost = window.location.pathname.startsWith("/glvis/")
+      ? `${window.location.host}/glvis-ws`
+      : host;
     console.log(`host = ${host}`);
 
     const touch = matchMedia("(hover: none), (pointer: coarse)").matches;
@@ -867,7 +870,7 @@
         websocketDialogActive: false,
         logWindowActive: false,
         connectWebsocketButtonLabel: "Connect",
-        socketHost: host,
+        socketHost: socketHost,
         socketPort: "8080",
         controlWindowActive: false,
         helpWindowActive: false,


### PR DESCRIPTION
## Summary
- Select `wss://` when the viewer is served over HTTPS, preventing mixed-content failures.
- Support reverse-proxy WebSocket routes and explicit WebSocket URLs.
- Add `?socket=` support to preconfigure and automatically connect the viewer.
## Example
Opening:
`https://example.org/glvis/live/?socket=/glvis-ws`
automatically connects to:
`wss://example.org/glvis-ws`
A plain Host and Port workflow remains supported for direct connections.


See also: https://github.com/mfem/containers/pull/9